### PR TITLE
Add ChatGPT conversation optimization and export extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# ChatGPT Conversation Toolkit
+
+适用于 Firefox 与 Microsoft Edge 的浏览器插件，提供：
+
+- **优化长会话卡顿**：一键隐藏旧消息，减少页面渲染压力。
+- **一键导出当前会话**：导出为 JSON 文件，包含所有消息内容。
+
+## 功能说明
+
+1. **优化长会话卡顿**
+   - 点击「优化长会话」按钮后，会隐藏较早的消息，仅保留最新 20 条。
+   - 需要查看完整内容时，可点击「恢复隐藏消息」。
+
+2. **一键导出当前会话全部消息**
+   - 点击「一键导出」按钮，会生成 JSON 文件并自动下载。
+   - 导出的内容包括隐藏的旧消息（如果曾执行优化）。
+
+## 安装方式
+
+### Firefox
+
+1. 打开 `about:debugging`。
+2. 点击「此 Firefox」→「临时载入附加组件」。
+3. 选择本项目根目录下的 `manifest.json`。
+
+### Microsoft Edge
+
+1. 打开 `edge://extensions`。
+2. 开启右上角「开发人员模式」。
+3. 点击「加载已解压的扩展」并选择本项目根目录。
+
+## 使用方法
+
+1. 打开 `https://chat.openai.com/` 或 `https://chatgpt.com/` 的对话页面。
+2. 页面右下角会出现「ChatGPT 工具」浮层。
+3. 点击对应按钮执行优化或导出。
+
+## 可选配置
+
+如需修改保留消息数量，可以在 `contentScript.js` 中调整 `keepLatest` 值。
+
+```js
+const state = {
+  isCollapsed: false,
+  keepLatest: 20, // 修改这里
+  collapsedNodes: [],
+  cachedNodes: [],
+};
+```
+
+## 文件说明
+
+- `manifest.json`：插件清单文件，定义脚本注入范围。
+- `contentScript.js`：核心逻辑（隐藏旧消息、导出会话）。
+- `styles.css`：工具浮层样式。

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,193 @@
+/*
+ * ChatGPT Conversation Toolkit
+ * - Optimize long conversations by collapsing older message DOM nodes.
+ * - Export the current conversation in JSON with one click.
+ */
+(() => {
+  const TOOLKIT_ID = "chatgpt-conversation-toolkit";
+  const STATUS_ID = "chatgpt-conversation-toolkit-status";
+
+  if (document.getElementById(TOOLKIT_ID)) {
+    return;
+  }
+
+  const state = {
+    isCollapsed: false,
+    keepLatest: 20,
+    collapsedNodes: [],
+    cachedNodes: [],
+  };
+
+  const getMessageNodes = () => Array.from(document.querySelectorAll("main article"));
+
+  const buildMessagePayload = (nodes) =>
+    nodes
+      .map((node, index) => {
+        const roleNode = node.querySelector("[data-message-author-role]");
+        let role = roleNode?.getAttribute("data-message-author-role") || "unknown";
+
+        if (role === "unknown") {
+          if (node.querySelector('img[alt*="User"], svg[aria-label*="User"]')) {
+            role = "user";
+          } else if (node.querySelector('img[alt*="ChatGPT"], svg[aria-label*="ChatGPT"]')) {
+            role = "assistant";
+          }
+        }
+
+        const text = node.innerText.trim();
+        return {
+          index: index + 1,
+          role,
+          text,
+        };
+      })
+      .filter((message) => message.text.length > 0);
+
+  const updateStatus = (message, tone = "info") => {
+    const status = document.getElementById(STATUS_ID);
+    if (!status) {
+      return;
+    }
+    status.textContent = message;
+    status.dataset.tone = tone;
+  };
+
+  const collapseOldMessages = () => {
+    const nodes = getMessageNodes();
+    if (nodes.length <= state.keepLatest) {
+      updateStatus("当前消息数量较少，无需优化。", "info");
+      return;
+    }
+
+    state.cachedNodes = nodes;
+    const toCollapse = nodes.slice(0, nodes.length - state.keepLatest);
+
+    state.collapsedNodes = toCollapse.map((node) => ({
+      node,
+      parent: node.parentNode,
+      nextSibling: node.nextSibling,
+    }));
+
+    toCollapse.forEach((node) => node.remove());
+
+    state.isCollapsed = true;
+    updateStatus(`已优化：隐藏 ${toCollapse.length} 条旧消息。`, "success");
+  };
+
+  const restoreMessages = () => {
+    if (!state.isCollapsed) {
+      updateStatus("没有需要恢复的消息。", "info");
+      return;
+    }
+
+    state.collapsedNodes.forEach(({ node, parent, nextSibling }) => {
+      if (!parent) {
+        return;
+      }
+      if (nextSibling && parent.contains(nextSibling)) {
+        parent.insertBefore(node, nextSibling);
+      } else {
+        parent.appendChild(node);
+      }
+    });
+
+    state.collapsedNodes = [];
+    state.isCollapsed = false;
+    updateStatus("已恢复所有消息。", "success");
+  };
+
+  const exportMessages = () => {
+    const visibleNodes = getMessageNodes();
+    const nodesForExport = state.isCollapsed
+      ? [...state.cachedNodes, ...visibleNodes.filter((node) => !state.cachedNodes.includes(node))]
+      : visibleNodes;
+
+    const payload = {
+      exportedAt: new Date().toISOString(),
+      url: window.location.href,
+      messageCount: nodesForExport.length,
+      messages: buildMessagePayload(nodesForExport),
+    };
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+
+    const dateTag = new Date().toISOString().replace(/[:.]/g, "-");
+    const filename = `chatgpt-session-${dateTag}.json`;
+
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(link.href);
+
+    updateStatus("导出已开始，请检查下载文件。", "success");
+  };
+
+  const buildToolbar = () => {
+    const container = document.createElement("section");
+    container.id = TOOLKIT_ID;
+    container.innerHTML = `
+      <div class="chatgpt-toolkit-header">
+        <strong>ChatGPT 工具</strong>
+        <span class="chatgpt-toolkit-subtitle">优化长会话 + 导出</span>
+      </div>
+      <div class="chatgpt-toolkit-actions">
+        <button type="button" class="chatgpt-toolkit-button" data-action="collapse">
+          优化长会话
+        </button>
+        <button type="button" class="chatgpt-toolkit-button" data-action="restore">
+          恢复隐藏消息
+        </button>
+        <button type="button" class="chatgpt-toolkit-button primary" data-action="export">
+          一键导出
+        </button>
+      </div>
+      <p id="${STATUS_ID}" class="chatgpt-toolkit-status" data-tone="info">准备就绪。</p>
+      <p class="chatgpt-toolkit-tip">提示：优化会隐藏旧消息，导出时会自动包含隐藏内容。</p>
+    `;
+
+    container.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+      const action = target.dataset.action;
+      if (!action) {
+        return;
+      }
+      if (action === "collapse") {
+        collapseOldMessages();
+      }
+      if (action === "restore") {
+        restoreMessages();
+      }
+      if (action === "export") {
+        exportMessages();
+      }
+    });
+
+    return container;
+  };
+
+  const attachToolbar = () => {
+    if (document.getElementById(TOOLKIT_ID)) {
+      return;
+    }
+    const toolbar = buildToolbar();
+    document.body.appendChild(toolbar);
+  };
+
+  attachToolbar();
+
+  const observer = new MutationObserver(() => {
+    if (!document.getElementById(TOOLKIT_ID)) {
+      attachToolbar();
+    }
+  });
+
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Conversation Toolkit",
+  "version": "1.0.0",
+  "description": "Optimize long ChatGPT conversations and export full sessions with one click.",
+  "content_scripts": [
+    {
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://chatgpt.com/*"
+      ],
+      "js": [
+        "contentScript.js"
+      ],
+      "css": [
+        "styles.css"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": [],
+  "host_permissions": [
+    "https://chat.openai.com/*",
+    "https://chatgpt.com/*"
+  ]
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,74 @@
+#chatgpt-conversation-toolkit {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 240px;
+  z-index: 2147483647;
+  background: #111827;
+  color: #f9fafb;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+  padding: 12px;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-subtitle {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-button {
+  width: 100%;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  background: #1f2937;
+  color: #f9fafb;
+  font-size: 13px;
+  transition: background 0.2s ease;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-button:hover {
+  background: #374151;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-button.primary {
+  background: #2563eb;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-button.primary:hover {
+  background: #1d4ed8;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-status {
+  margin: 10px 0 6px;
+  font-size: 12px;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-status[data-tone="success"] {
+  color: #34d399;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-status[data-tone="info"] {
+  color: #9ca3af;
+}
+
+#chatgpt-conversation-toolkit .chatgpt-toolkit-tip {
+  margin: 0;
+  font-size: 11px;
+  color: #6b7280;
+}


### PR DESCRIPTION
### Motivation
- Reduce UI jank for long ChatGPT sessions by collapsing older message DOM nodes to lower render cost.
- Provide a simple way to export the entire conversation (including collapsed content) as a JSON file for backup or analysis.

### Description
- Add `manifest.json` (MV3) to inject a content script and stylesheet into ChatGPT pages (`https://chat.openai.com/*`, `https://chatgpt.com/*`).
- Implement `contentScript.js` which injects a floating toolbar that can `collapse` old messages, `restore` them, and `export` the full session as a JSON file; it tracks `cachedNodes` so collapsed content is preserved for export.
- Add `styles.css` to style the floating UI and status messages for the toolkit.
- Add `README.md` with installation and usage instructions for Firefox and Microsoft Edge and a note about the configurable `keepLatest` value.

### Testing
- Ran a Playwright-based smoke test that launched headless Chromium with the extension loaded and navigated to `https://chatgpt.com/`, which completed and produced a screenshot artifact (`artifacts/chatgpt-toolkit.png`) confirming the overlay injected successfully.
- No unit tests were added; manual/interactive validation is described in `README.md` for local testing in Firefox/Edge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976e36ecf70832ebace8509f70b35ea)